### PR TITLE
Add rate limiting for auth post routes

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,6 +15,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
+        "express-rate-limit": "^7.5.0",
         "express-validator": "^7.0.1",
         "helmet": "^7.0.0",
         "jsonwebtoken": "^9.0.2",
@@ -3965,6 +3966,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
+      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "^4.11 || 5 || ^5.0.0-beta.1"
       }
     },
     "node_modules/express-validator": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -24,6 +24,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
+    "express-rate-limit": "^7.5.0",
     "express-validator": "^7.0.1",
     "helmet": "^7.0.0",
     "jsonwebtoken": "^9.0.2",

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -22,6 +22,7 @@ dotenv.config();
  */
 export const createApp = (): express.Application => {
   const app = express();
+
   app.use(cors());
   app.use(helmet());
   app.use(morgan('dev'));


### PR DESCRIPTION
Using express-rate-limit, set some default/arbitrary (15 min/5 attempts) rate limit for login and registration. Can be adjusted in the future, but wanted to get the foundations in place. Tests still pass.