### PR TITLE
Modify auth error responses to generalize errors

### DIFF
--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -70,12 +70,14 @@ router.post(
     } catch (error) {
       if (error instanceof Error && error.message === 'Invalid credentials') {
         return res.status(401).json({
-          error: 'Invalid email or password',
+          status: 'failure',
+          error: 'Invalid credentials',
         });
       }
 
       console.error('Login error:', error);
       return res.status(500).json({
+        status: 'failure',
         error: 'Internal server error',
       });
     }
@@ -102,6 +104,7 @@ router.post(
     try {
       const newUser = await register({ email, password, name });
 
+      /** @todo send verification email */
       res.status(201).json({
         status: 'ok',
         message: 'Registration successful',
@@ -109,8 +112,10 @@ router.post(
       });
     } catch (error) {
       if (error instanceof Error && error.message === 'User already exists') {
-        return res.status(409).json({
-          error: 'User already exists' /** @todo is this an issue letting someone know an email exists? */,
+        /** @todo send registration attempt notification */
+        res.status(201).json({
+          status: 'ok',
+          message: 'Registration successful.',
         });
       }
 
@@ -126,11 +131,13 @@ router.post(
 router.get('/logout', (req, res) => {
   if (req.cookies['jwt']) {
     return res.clearCookie('jwt').status(200).json({
+      status: 'ok',
       message: 'You have logged out',
     });
   }
 
   return res.status(200).json({
+    status: 'ok',
     message: 'You have logged out',
   });
 });
@@ -138,11 +145,15 @@ router.get('/logout', (req, res) => {
 router.get('/whoami', optionalAuth, (req, res) => {
   if (req.user) {
     return res.status(200).json({
+      status: 'ok',
       user: req.user,
     });
   }
 
-  return res.status(204).send();
+  return res.status(204).json({
+    status: 'ok',
+    user: {},
+  });
 });
 
 export default router;

--- a/backend/src/services/authentication.ts
+++ b/backend/src/services/authentication.ts
@@ -38,7 +38,7 @@ export async function login(email: string, password: string): Promise<Authentica
 
   const isMatch = await user.comparePassword(password);
   if (!isMatch) {
-    throw new Error('Invalid credentials');
+    throw new Error('Invalid credentials'); /** @todo type for authentication error */
   }
 
   return { user: user.toSafeObject() };

--- a/backend/tests/routes/auth.test.ts
+++ b/backend/tests/routes/auth.test.ts
@@ -26,7 +26,7 @@ describe('Auth Routes', () => {
       const response = await loginUser('test@example.com', 'wrongpassword');
 
       expect(response.status).toBe(401);
-      expect(response.body.error).toBe('Invalid email or password');
+      expect(response.body.error).toBe('Invalid credentials');
     });
 
     it('should return 200 with JWT cookie on success', async () => {
@@ -59,7 +59,7 @@ describe('Auth Routes', () => {
       expect(response.body.user).toEqual(mockUser);
     });
 
-    it('should return 409 for existing user', async () => {
+    it('should obfuscate if user exists', async () => {
       vi.mocked(register).mockRejectedValue(new Error('User already exists'));
 
       const response = await registerUser({
@@ -68,8 +68,8 @@ describe('Auth Routes', () => {
         name: 'Existing User',
       });
 
-      expect(response.status).toBe(409);
-      expect(response.body.error).toBe('User already exists');
+      expect(response.status).toBe(201);
+      expect(response.body.message).toBe('Registration successful.');
     });
   });
 


### PR DESCRIPTION
We don't want to give information about our users away -- so instead of saying "email exists" when registration fails, we'll just say it's successful. In the future we'll implement confirmation/verification emails to accompany registration.