### PR TITLE
Configure CORS for frontend

### DIFF
--- a/backend/src/config/cors.ts
+++ b/backend/src/config/cors.ts
@@ -1,0 +1,8 @@
+import type { CorsOptions } from 'cors';
+
+export const corsOptions: CorsOptions = {
+  origin: process.env.FRONTEND_URI || 'http://localhost:3000',
+  credentials: true,
+  methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'],
+  allowedHeaders: ['Content-Type', 'Authorization', 'X-CSRF-Token'],
+};

--- a/backend/src/config/jwt.ts
+++ b/backend/src/config/jwt.ts
@@ -1,0 +1,7 @@
+import type { CookieOptions } from 'express';
+
+export const jwtConfig: CookieOptions = {
+  httpOnly: true,
+  secure: process.env.NODE_ENV === 'production',
+  sameSite: 'strict',
+};

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -7,6 +7,7 @@ import mongoose from 'mongoose';
 import morgan from 'morgan';
 import passport from 'passport';
 
+import { corsOptions } from './config/cors';
 import { requireAuth } from './middleware/auth';
 import authRouter from './routes/auth';
 
@@ -23,7 +24,7 @@ dotenv.config();
 export const createApp = (): express.Application => {
   const app = express();
 
-  app.use(cors());
+  app.use(cors(corsOptions));
   app.use(helmet());
   app.use(morgan('dev'));
   app.use(express.json());

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -3,6 +3,7 @@ import rateLimit from 'express-rate-limit';
 import { body as validateBody, validationResult } from 'express-validator';
 import jwt from 'jsonwebtoken';
 
+import { jwtConfig } from '../config/jwt';
 import { JwtPayload } from '../config/passport';
 import { optionalAuth } from '../middleware/auth';
 import { register, login } from '../services/authentication';
@@ -55,18 +56,11 @@ router.post(
 
       const token = jwt.sign(payload, JWT_SECRET);
 
-      res
-        .cookie('jwt', token, {
-          httpOnly: true,
-          secure: process.env.NODE_ENV === 'production',
-          sameSite: 'strict',
-        })
-        .status(200)
-        .json({
-          status: 'ok',
-          message: 'Login successful',
-          user: user,
-        });
+      res.cookie('jwt', token, jwtConfig).status(200).json({
+        status: 'ok',
+        message: 'Login successful',
+        user: user,
+      });
     } catch (error) {
       if (error instanceof Error && error.message === 'Invalid credentials') {
         return res.status(401).json({


### PR DESCRIPTION
Configure CORS middleware to filter on the front-end, using .env -- default to locahost for development.

Extracted cors and jwt configuraitons to /config directory so we can easily manage them.