### PR TITLE
Implement CSRF tokens

### DIFF
--- a/backend/.prettierrc
+++ b/backend/.prettierrc
@@ -2,7 +2,7 @@
   "bracketSpacing": true,
   "experimentalOperatorPosition": "start",
   "objectWrap": "preserve",
-  "printWidth": 120,
+  "printWidth": 96,
   "semi": true,
   "singleQuote": true,
   "tabWidth": 2,

--- a/backend/src/config/cookies.ts
+++ b/backend/src/config/cookies.ts
@@ -1,0 +1,17 @@
+import type { CookieOptions } from 'express';
+
+export const jwtCookie = (): CookieOptions => {
+  return {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'strict',
+  };
+};
+
+export const csrfCookie = (): CookieOptions => {
+  return {
+    httpOnly: false,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'strict',
+  };
+};

--- a/backend/src/config/jwt.ts
+++ b/backend/src/config/jwt.ts
@@ -1,7 +1,0 @@
-import type { CookieOptions } from 'express';
-
-export const jwtConfig: CookieOptions = {
-  httpOnly: true,
-  secure: process.env.NODE_ENV === 'production',
-  sameSite: 'strict',
-};

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -9,6 +9,7 @@ import passport from 'passport';
 
 import { corsOptions } from './config/cors';
 import { requireAuth } from './middleware/auth';
+import { csrfProtection } from './middleware/csrf';
 import authRouter from './routes/auth';
 
 import './config/passport'; // authentication strategies
@@ -31,6 +32,9 @@ export const createApp = (): express.Application => {
   app.use(cookieParser());
   app.use(express.urlencoded({ extended: true }));
   app.use(passport.initialize());
+
+  app.use('/api', csrfProtection);
+  app.use('/protected', csrfProtection);
 
   app.use('/auth', authRouter);
 

--- a/backend/src/middleware/csrf.ts
+++ b/backend/src/middleware/csrf.ts
@@ -1,0 +1,24 @@
+import crypto from 'crypto';
+
+import type { Request, Response, NextFunction } from 'express';
+
+const FILTERED_METHODS = ['POST', 'PUT', 'DELETE', 'PATCH'];
+
+export const generateCSRFToken = (): string => crypto.randomBytes(32).toString('hex');
+
+export const csrfProtection = (req: Request, res: Response, next: NextFunction): void => {
+  if (FILTERED_METHODS.includes(req.method)) {
+    const tokenFromHeader = req?.headers?.['x-csrf-token'];
+    const tokenFromCookie = req?.cookies?.csrfToken;
+
+    const noTokens = !tokenFromCookie || !tokenFromHeader;
+    const tokensDontMatch = tokenFromCookie !== tokenFromHeader;
+
+    if (noTokens || tokensDontMatch) {
+      res.status(403).json({ error: 'Forbidden' });
+
+      return;
+    }
+  }
+  next();
+};

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -3,9 +3,10 @@ import rateLimit from 'express-rate-limit';
 import { body as validateBody, validationResult } from 'express-validator';
 import jwt from 'jsonwebtoken';
 
-import { jwtConfig } from '../config/jwt';
+import { csrfCookie, jwtCookie } from '../config/cookies';
 import { JwtPayload } from '../config/passport';
 import { optionalAuth } from '../middleware/auth';
+import { generateCSRFToken } from '../middleware/csrf';
 import { register, login } from '../services/authentication';
 
 const router = Router();
@@ -56,7 +57,7 @@ router.post(
 
       const token = jwt.sign(payload, JWT_SECRET);
 
-      res.cookie('jwt', token, jwtConfig).status(200).json({
+      res.cookie('jwt', token, jwtCookie()).cookie('csrfToken', generateCSRFToken(), csrfCookie()).status(200).json({
         status: 'ok',
         message: 'Login successful',
         user: user,
@@ -121,6 +122,12 @@ router.post(
   },
 );
 /* ------------ /REGISTRATION------------ */
+
+router.get('/csrf-token', optionalAuth, (req, res) => {
+  const token = generateCSRFToken();
+
+  res.cookie('csrfToken', token, csrfCookie()).json({ csrfToken: token });
+});
 
 router.get('/logout', (req, res) => {
   if (req.cookies['jwt']) {

--- a/backend/tests/middleware/csrf.test.ts
+++ b/backend/tests/middleware/csrf.test.ts
@@ -1,0 +1,287 @@
+import crypto from 'crypto';
+
+import type { Request, Response, NextFunction } from 'express';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { csrfProtection, generateCSRFToken } from '../../src/middleware/csrf';
+
+describe('CSRF Middleware', () => {
+  let mockReq: Partial<Request>;
+  let mockRes: Partial<Response>;
+  let mockNext: typeof vi.fn;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockReq = {
+      method: 'GET',
+      headers: {},
+      cookies: {},
+    };
+
+    mockRes = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn().mockReturnThis(),
+    };
+
+    mockNext = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('generateCSRFToken', () => {
+    it('should generate a 64-character hex string', () => {
+      const token = generateCSRFToken();
+
+      expect(token).toMatch(/^[a-f0-9]{64}$/);
+      expect(token.length).toBe(64);
+    });
+
+    it('should generate unique tokens', () => {
+      const token1 = generateCSRFToken();
+      const token2 = generateCSRFToken();
+
+      expect(token1).not.toBe(token2);
+    });
+
+    it('should use crypto.randomBytes correctly', () => {
+      const mockRandomBytes = vi.spyOn(crypto, 'randomBytes');
+      mockRandomBytes.mockImplementation(() => Buffer.from('a'.repeat(32)));
+
+      const token = generateCSRFToken();
+
+      expect(mockRandomBytes).toHaveBeenCalledWith(32);
+      expect(token).toBe('61'.repeat(32));
+    });
+  });
+
+  describe('csrfProtection middleware', () => {
+    describe('Safe HTTP methods (GET, HEAD, OPTIONS)', () => {
+      ['GET', 'HEAD', 'OPTIONS'].forEach((method) => {
+        it(`should pass through ${method} requests without CSRF validation`, () => {
+          mockReq.method = method;
+
+          csrfProtection(mockReq as Request, mockRes as Response, mockNext);
+
+          expect(mockNext).toHaveBeenCalledWith();
+          expect(mockRes.status).not.toHaveBeenCalled();
+          expect(mockRes.json).not.toHaveBeenCalled();
+        });
+      });
+    });
+
+    describe('State-changing HTTP methods (POST, PUT, DELETE, PATCH)', () => {
+      ['POST', 'PUT', 'DELETE', 'PATCH'].forEach((method) => {
+        describe(`${method} requests`, () => {
+          beforeEach(() => {
+            mockReq.method = method;
+          });
+
+          it('should return 403 when no CSRF token in header', () => {
+            mockReq.headers = {};
+            mockReq.cookies = { csrfToken: 'valid-token' };
+
+            csrfProtection(mockReq as Request, mockRes as Response, mockNext);
+
+            expect(mockRes.status).toHaveBeenCalledWith(403);
+            expect(mockRes.json).toHaveBeenCalledWith({ error: 'Forbidden' });
+            expect(mockNext).not.toHaveBeenCalled();
+          });
+
+          it('should return 403 when no CSRF token in cookie', () => {
+            mockReq.headers = { 'x-csrf-token': 'valid-token' };
+            mockReq.cookies = {};
+
+            csrfProtection(mockReq as Request, mockRes as Response, mockNext);
+
+            expect(mockRes.status).toHaveBeenCalledWith(403);
+            expect(mockRes.json).toHaveBeenCalledWith({ error: 'Forbidden' });
+            expect(mockNext).not.toHaveBeenCalled();
+          });
+
+          it('should return 403 when tokens do not match', () => {
+            mockReq.headers = { 'x-csrf-token': 'header-token' };
+            mockReq.cookies = { csrfToken: 'cookie-token' };
+
+            csrfProtection(mockReq as Request, mockRes as Response, mockNext);
+
+            expect(mockRes.status).toHaveBeenCalledWith(403);
+            expect(mockRes.json).toHaveBeenCalledWith({ error: 'Forbidden' });
+            expect(mockNext).not.toHaveBeenCalled();
+          });
+
+          it('should call next() when tokens match', () => {
+            const token = 'matching-token';
+            mockReq.headers = { 'x-csrf-token': token };
+            mockReq.cookies = { csrfToken: token };
+
+            csrfProtection(mockReq as Request, mockRes as Response, mockNext);
+
+            expect(mockNext).toHaveBeenCalledWith();
+            expect(mockRes.status).not.toHaveBeenCalled();
+            expect(mockRes.json).not.toHaveBeenCalled();
+          });
+
+          it('should handle empty string tokens as invalid', () => {
+            mockReq.headers = { 'x-csrf-token': '' };
+            mockReq.cookies = { csrfToken: '' };
+
+            csrfProtection(mockReq as Request, mockRes as Response, mockNext);
+
+            expect(mockRes.status).toHaveBeenCalledWith(403);
+            expect(mockRes.json).toHaveBeenCalledWith({ error: 'Forbidden' });
+            expect(mockNext).not.toHaveBeenCalled();
+          });
+
+          it('should handle undefined tokens', () => {
+            mockReq.headers = { 'x-csrf-token': undefined };
+            mockReq.cookies = { csrfToken: undefined };
+
+            csrfProtection(mockReq as Request, mockRes as Response, mockNext);
+
+            expect(mockRes.status).toHaveBeenCalledWith(403);
+            expect(mockRes.json).toHaveBeenCalledWith({ error: 'Forbidden' });
+            expect(mockNext).not.toHaveBeenCalled();
+          });
+
+          it('should handle null tokens', () => {
+            mockReq.headers = { 'x-csrf-token': void 0 };
+            mockReq.cookies = { csrfToken: null };
+
+            csrfProtection(mockReq as Request, mockRes as Response, mockNext);
+
+            expect(mockRes.status).toHaveBeenCalledWith(403);
+            expect(mockRes.json).toHaveBeenCalledWith({ error: 'Forbidden' });
+            expect(mockNext).not.toHaveBeenCalled();
+          });
+        });
+      });
+    });
+
+    describe('Edge cases', () => {
+      it('should handle missing headers object', () => {
+        mockReq.method = 'POST';
+        mockReq.headers = undefined;
+        mockReq.cookies = { csrfToken: 'token' };
+
+        csrfProtection(mockReq as Request, mockRes as Response, mockNext);
+
+        expect(mockRes.status).toHaveBeenCalledWith(403);
+        expect(mockRes.json).toHaveBeenCalledWith({ error: 'Forbidden' });
+        expect(mockNext).not.toHaveBeenCalled();
+      });
+
+      it('should handle missing cookies object', () => {
+        mockReq.method = 'POST';
+        mockReq.headers = { 'x-csrf-token': 'token' };
+        mockReq.cookies = undefined;
+
+        csrfProtection(mockReq as Request, mockRes as Response, mockNext);
+
+        expect(mockRes.status).toHaveBeenCalledWith(403);
+        expect(mockRes.json).toHaveBeenCalledWith({ error: 'Forbidden' });
+        expect(mockNext).not.toHaveBeenCalled();
+      });
+
+      it('should be case-sensitive for header name', () => {
+        mockReq.method = 'POST';
+        mockReq.headers = { 'X-CSRF-TOKEN': 'token' }; // uppercase
+        mockReq.cookies = { csrfToken: 'token' };
+
+        csrfProtection(mockReq as Request, mockRes as Response, mockNext);
+
+        expect(mockRes.status).toHaveBeenCalledWith(403);
+        expect(mockRes.json).toHaveBeenCalledWith({ error: 'Forbidden' });
+        expect(mockNext).not.toHaveBeenCalled();
+      });
+
+      it('should handle whitespace in tokens', () => {
+        mockReq.method = 'POST';
+        mockReq.headers = { 'x-csrf-token': ' token ' };
+        mockReq.cookies = { csrfToken: 'token' };
+
+        csrfProtection(mockReq as Request, mockRes as Response, mockNext);
+
+        expect(mockRes.status).toHaveBeenCalledWith(403);
+        expect(mockRes.json).toHaveBeenCalledWith({ error: 'Forbidden' });
+        expect(mockNext).not.toHaveBeenCalled();
+      });
+
+      it('should handle numeric tokens', () => {
+        const token = '12345';
+        mockReq.method = 'POST';
+        mockReq.headers = { 'x-csrf-token': token };
+        mockReq.cookies = { csrfToken: token };
+
+        csrfProtection(mockReq as Request, mockRes as Response, mockNext);
+
+        expect(mockNext).toHaveBeenCalledWith();
+        expect(mockRes.status).not.toHaveBeenCalled();
+        expect(mockRes.json).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('Integration scenarios', () => {
+      it('should work with real generated tokens', () => {
+        const token = generateCSRFToken();
+        mockReq.method = 'POST';
+        mockReq.headers = { 'x-csrf-token': token };
+        mockReq.cookies = { csrfToken: token };
+
+        csrfProtection(mockReq as Request, mockRes as Response, mockNext);
+
+        expect(mockNext).toHaveBeenCalledWith();
+        expect(mockRes.status).not.toHaveBeenCalled();
+        expect(mockRes.json).not.toHaveBeenCalled();
+      });
+
+      it('should reject when using different generated tokens', () => {
+        const token1 = generateCSRFToken();
+        const token2 = generateCSRFToken();
+
+        mockReq.method = 'PUT';
+        mockReq.headers = { 'x-csrf-token': token1 };
+        mockReq.cookies = { csrfToken: token2 };
+
+        csrfProtection(mockReq as Request, mockRes as Response, mockNext);
+
+        expect(mockRes.status).toHaveBeenCalledWith(403);
+        expect(mockRes.json).toHaveBeenCalledWith({ error: 'Forbidden' });
+        expect(mockNext).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('CSRF constant validation', () => {
+    it('should protect all state-changing methods', () => {
+      // This test ensures we don't miss any HTTP methods that should be protected
+      const protectedMethods = ['POST', 'PUT', 'DELETE', 'PATCH'];
+      const safeMethods = ['GET', 'HEAD', 'OPTIONS'];
+
+      protectedMethods.forEach((method) => {
+        mockReq.method = method;
+        mockReq.headers = {};
+        mockReq.cookies = {};
+
+        const mockNextLocal = vi.fn();
+        csrfProtection(mockReq as Request, mockRes as Response, mockNextLocal);
+
+        expect(mockRes.status).toHaveBeenCalledWith(403);
+        expect(mockNextLocal).not.toHaveBeenCalled();
+      });
+
+      safeMethods.forEach((method) => {
+        mockReq.method = method;
+        mockReq.headers = {};
+        mockReq.cookies = {};
+
+        const mockNextLocal = vi.fn();
+        csrfProtection(mockReq as Request, mockRes as Response, mockNextLocal);
+
+        expect(mockNextLocal).toHaveBeenCalledWith();
+      });
+    });
+  });
+});


### PR DESCRIPTION
CSRF tokens will be used in conjunction with JWT-in-cookies and CORS as part of our security strategy. We'll send a CSRF token in the header and the cookie and if they don't match it'll be forbidden.

Added unit tests for CSRF middleware too.