### PR TITLE
Adjust morgan usage for auth logging

### DIFF
--- a/backend/src/config/morgan.ts
+++ b/backend/src/config/morgan.ts
@@ -1,0 +1,57 @@
+import type { Request, Response } from 'express';
+import type { Options } from 'morgan';
+import morgan from 'morgan';
+
+import { SafeUser } from '../types/user';
+
+/**
+ * The `safe-body` token represents the request body
+ * with privacy/security elements redacted for logging
+ */
+morgan.token('safe-body', (req: Request): string => {
+  if (!req.body || typeof req.body !== 'object') {
+    return '-';
+  }
+
+  const toRedact = ['password', 'token', 'jwt', 'authorization'];
+
+  const safeBody = Object.entries(req.body).reduce(
+    (acc, [key, val]) => {
+      const needsRedacting = toRedact.includes(key);
+      acc[key] = needsRedacting ? '[REDACTED]' : val;
+
+      return acc;
+    },
+    {} as Record<string, unknown>,
+  );
+
+  return JSON.stringify(safeBody);
+});
+
+morgan.token('user-id', (req: Request): string => {
+  return (req?.user as SafeUser)?.id ?? 'anonymous';
+});
+
+export const morganFormat = (): string => {
+  return process.env.NODE_ENV === 'development' ? 'dev' : 'combined';
+};
+
+export const authLogFormat = [
+  ':remote-addr',
+  ':user-id',
+  '":method :url"',
+  ':status',
+  ':response-time ms',
+  '":user-agent"',
+  'Body=:safe-body',
+].join(' ');
+
+export const morganConfig = (): Options<Request, Response> => {
+  return {};
+};
+
+export const authMorganConfig = (): Options<Request, Response> => {
+  return {
+    skip: (req: Request) => !req.path.startsWith('/auth'),
+  };
+};

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -9,6 +9,7 @@ import passport from 'passport';
 
 import { corsOptions } from './config/cors';
 import { helmetConfig } from './config/helmet';
+import { authLogFormat, authMorganConfig, morganConfig, morganFormat } from './config/morgan';
 import { requireAuth } from './middleware/auth';
 import { csrfProtection } from './middleware/csrf';
 import authRouter from './routes/auth';
@@ -26,12 +27,13 @@ dotenv.config();
 export const createApp = (): express.Application => {
   const app = express();
 
-  app.use(cors(corsOptions));
-  app.use(helmet(helmetConfig));
-  app.use(morgan('dev'));
-  app.use(express.json());
   app.use(cookieParser());
+  app.use(cors(corsOptions));
+  app.use(express.json());
   app.use(express.urlencoded({ extended: true }));
+  app.use(helmet(helmetConfig));
+  app.use(morgan(authLogFormat, authMorganConfig()));
+  app.use(morgan(morganFormat(), morganConfig()));
   app.use(passport.initialize());
 
   app.use('/api', csrfProtection);

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -62,7 +62,9 @@ router.post(
         message: 'Login successful',
         user: user,
       });
+      console.log(`[AUTH_SUCCESS] Login: ${user.email} from ${req.ip}`);
     } catch (error) {
+      console.log(`[AUTH_FAILED] Login attempt: ${req.body.email || 'unknown'} from ${req.ip}`);
       if (error instanceof Error && error.message === 'Invalid credentials') {
         return res.status(401).json({
           status: 'failure',
@@ -105,8 +107,10 @@ router.post(
         message: 'Registration successful',
         user: newUser.user,
       });
+      console.log(`[AUTH_SUCCESS] Registration: ${newUser.user.email} from ${req.ip}`);
     } catch (error) {
       if (error instanceof Error && error.message === 'User already exists') {
+        console.log(`[AUTH_INFO] Registration attempt for existing user: ${email} from ${req.ip}`);
         /** @todo send registration attempt notification */
         res.status(201).json({
           status: 'ok',
@@ -131,6 +135,7 @@ router.get('/csrf-token', optionalAuth, (req, res) => {
 
 router.get('/logout', (req, res) => {
   if (req.cookies['jwt']) {
+    console.log(`[AUTH_INFO] Logout from ${req.ip}`);
     return res.clearCookie('jwt').status(200).json({
       status: 'ok',
       message: 'You have logged out',


### PR DESCRIPTION
We want to better record API usage in the auth paths -- setting up a separate logger and using some custom tokens with  morgan. This allows us to see who's trying to log in, etc.