### PR TITLE
Implement RBAC (role-based access control)

### DIFF
--- a/backend/src/config/permissions.ts
+++ b/backend/src/config/permissions.ts
@@ -1,0 +1,101 @@
+import { ValuesOfObject } from '../utils/extractTypes';
+
+export const HouseholdPermissions = {
+  HOUSEHOLD_VIEW:   'household:view',
+  HOUSEHOLD_UPDATE: 'household:update', 
+  HOUSEHOLD_DELETE: 'household:delete',
+  
+  HOUSEHOLD_INVITE_MEMBERS:      'household:invite_members',
+  HOUSEHOLD_REMOVE_MEMBERS:      'household:remove_members',
+  HOUSEHOLD_UPDATE_MEMBER_ROLES: 'household:update_member_roles',
+  HOUSEHOLD_TRANSFER_OWNERSHIP:  'household:transfer_ownership',
+} as const;
+
+export const UserPermissions = {
+  USER_VIEW_PROFILE:       'user:view_profile',
+  USER_UPDATE_OWN_PROFILE: 'user:update_own_profile',
+  USER_UPDATE_ANY_PROFILE: 'user:update_any_profile',
+  USER_DELETE_OWN_ACCOUNT: 'user:delete_own_account',
+  USER_DELETE_ANY_ACCOUNT: 'user:delete_any_account',
+} as const;
+
+export const AssetPermissions = {
+  ASSET_CREATE: 'asset:create',
+  ASSET_VIEW:   'asset:view',
+  ASSET_UPDATE: 'asset:update',
+  ASSET_DELETE: 'asset:delete',
+  
+  ASSET_TRANSFER: 'asset:transfer',  // Move to different household
+  ASSET_ARCHIVE:  'asset:archive',   // Soft delete for historical purposes
+} as const;
+
+export const ManualPermissions = {
+  // File operations
+  MANUAL_UPLOAD:   'manual:upload',
+  MANUAL_VIEW:     'manual:view',
+  MANUAL_DOWNLOAD: 'manual:download',
+  MANUAL_UPDATE:   'manual:update',     // Metadata only
+  MANUAL_DELETE:   'manual:delete',
+  
+  // Content operations
+  MANUAL_VIEW_CONTENT:        'manual:view_content', // OCR text
+  MANUAL_EDIT_EXTRACTED_TEXT: 'manual:edit_extracted_text',
+  
+  // Advanced operations
+  MANUAL_BULK_UPLOAD: 'manual:bulk_upload',
+  MANUAL_EXPORT:      'manual:export',   // Export multiple manuals
+} as const;
+
+export const TaskPermissions = {
+  // Basic CRUD
+  TASK_CREATE: 'task:create',
+  TASK_VIEW:   'task:view',
+  TASK_UPDATE: 'task:update',
+  TASK_DELETE: 'task:delete',
+  
+  // Task operations
+  TASK_COMPLETE: 'task:complete',
+  TASK_ASSIGN:   'task:assign',       // Assign to other users
+  TASK_UNASSIGN: 'task:unassign',
+  
+  // Scheduling
+  TASK_UPDATE_SCHEDULE: 'task:update_schedule',
+  TASK_SKIP_OCCURRENCE: 'task:skip_occurrence',
+  
+  // History and reporting
+  TASK_VIEW_HISTORY:   'task:view_history',
+  TASK_VIEW_ANALYTICS: 'task:view_analytics',
+} as const;
+
+export const DocumentPermissions = {
+  // Basic CRUD
+  DOCUMENT_CREATE: 'document:create',
+  DOCUMENT_VIEW:   'document:view',
+  DOCUMENT_UPDATE: 'document:update',
+  DOCUMENT_DELETE: 'document:delete',
+  
+  // Content operations
+  DOCUMENT_EDIT_CONTENT: 'document:edit_content',
+  
+  // Ownership-specific
+  DOCUMENT_UPDATE_OWN: 'document:update_own',
+  DOCUMENT_DELETE_OWN: 'document:delete_own',
+} as const;
+
+export const SearchPermissions = {
+  SEARCH_MANUALS:        'search:manuals',
+  SEARCH_ASSETS:         'search:assets',
+  SEARCH_TASKS:          'search:tasks',
+  SEARCH_DOCUMENTS:      'search:documents',
+  SEARCH_GLOBAL:         'search:global',           // Cross-category search
+  SEARCH_EXPORT_RESULTS: 'search:export_results',
+} as const;
+
+export type ALL_PERMISSIONS = ValuesOfObject<typeof HouseholdPermissions>
+  | ValuesOfObject<typeof UserPermissions>
+  | ValuesOfObject<typeof AssetPermissions>
+  | ValuesOfObject<typeof ManualPermissions>
+  | ValuesOfObject<typeof TaskPermissions>
+  | ValuesOfObject<typeof DocumentPermissions>
+  | ValuesOfObject<typeof SearchPermissions>
+

--- a/backend/src/config/roles.ts
+++ b/backend/src/config/roles.ts
@@ -1,0 +1,95 @@
+import { 
+  HouseholdPermissions, 
+  UserPermissions, 
+  AssetPermissions, 
+  ManualPermissions, 
+  TaskPermissions,
+  DocumentPermissions,
+  SearchPermissions 
+} from './permissions';
+
+/**
+ * No permission limits on owners -- they can do it all!
+ */
+export const Owner = [
+  ...Object.values(HouseholdPermissions),
+  ...Object.values(UserPermissions),
+  ...Object.values(AssetPermissions),
+  ...Object.values(ManualPermissions),
+  ...Object.values(TaskPermissions),
+  ...Object.values(DocumentPermissions),
+  ...Object.values(SearchPermissions),
+];
+
+/**
+ * Admins can invite people, update households and have full control over
+ * resources. However they do not have the ability to modify membership once
+ * someone has been added. 
+ */
+export const Admin = [
+  HouseholdPermissions.HOUSEHOLD_VIEW,
+  HouseholdPermissions.HOUSEHOLD_UPDATE,
+  HouseholdPermissions.HOUSEHOLD_INVITE_MEMBERS,
+
+  UserPermissions.USER_VIEW_PROFILE,
+  UserPermissions.USER_UPDATE_OWN_PROFILE,
+  UserPermissions.USER_DELETE_OWN_ACCOUNT,
+
+  ...Object.values(AssetPermissions).filter(x => x !== AssetPermissions.ASSET_TRANSFER),
+  ...Object.values(ManualPermissions),
+  ...Object.values(TaskPermissions),
+  ...Object.values(DocumentPermissions),
+  ...Object.values(SearchPermissions),
+];
+
+/**
+ * Members have stricter controls over household resources -- they can upload
+ * modify and edit manuals/documents, but can't remove or transfer assets. They
+ * can be assigned to a task, but not edit or create tasks. 
+ */
+export const Member = [
+    HouseholdPermissions.HOUSEHOLD_VIEW,
+    UserPermissions.USER_VIEW_PROFILE,
+    UserPermissions.USER_UPDATE_OWN_PROFILE,
+    UserPermissions.USER_DELETE_OWN_ACCOUNT,
+    
+    AssetPermissions.ASSET_CREATE,
+    AssetPermissions.ASSET_VIEW,
+    AssetPermissions.ASSET_UPDATE,
+    
+    TaskPermissions.TASK_VIEW,
+    TaskPermissions.TASK_COMPLETE,
+    TaskPermissions.TASK_VIEW_HISTORY,
+    
+    ...Object.values(ManualPermissions),
+    DocumentPermissions.DOCUMENT_CREATE,
+    DocumentPermissions.DOCUMENT_VIEW,
+    DocumentPermissions.DOCUMENT_UPDATE_OWN,
+    DocumentPermissions.DOCUMENT_DELETE_OWN,
+    
+    SearchPermissions.SEARCH_MANUALS,
+    SearchPermissions.SEARCH_ASSETS,
+    SearchPermissions.SEARCH_TASKS,
+    SearchPermissions.SEARCH_DOCUMENTS,
+];
+
+/**
+ * Guests are basically read-only -- limited access to content and search,
+ * no ability edit or upload additional content. 
+ */
+export const Guest = [
+    HouseholdPermissions.HOUSEHOLD_VIEW,
+    UserPermissions.USER_VIEW_PROFILE,
+    UserPermissions.USER_UPDATE_OWN_PROFILE,
+    
+    AssetPermissions.ASSET_VIEW,
+    ManualPermissions.MANUAL_VIEW,
+    ManualPermissions.MANUAL_DOWNLOAD,
+    ManualPermissions.MANUAL_VIEW_CONTENT,
+    TaskPermissions.TASK_VIEW,
+    DocumentPermissions.DOCUMENT_VIEW,
+    
+    SearchPermissions.SEARCH_MANUALS,
+    SearchPermissions.SEARCH_ASSETS,
+    SearchPermissions.SEARCH_TASKS,
+  ];

--- a/backend/src/middleware/rbac.ts
+++ b/backend/src/middleware/rbac.ts
@@ -1,0 +1,66 @@
+import { ALL_PERMISSIONS } from '../config/permissions';
+import { ERROR_MESSAGES } from '../constants';
+import {
+  hasAllPermissions,
+  hasAnyPermission,
+  hasPermission,
+} from '../services/permission';
+
+import type {Request, Response, NextFunction, RequestHandler} from 'express';
+
+export function requirePermission(permission: ALL_PERMISSIONS): RequestHandler {
+  return function(req: Request, res: Response, next: NextFunction) {
+    const {user} = req;
+    const householdId = req.params.id;
+
+    if(!user || !householdId) {
+      res.apiError(401, ERROR_MESSAGES.UNAUTHORIZED);
+      return;
+    }
+
+    if(!hasPermission(user, householdId, permission)) {
+      res.apiError(403, ERROR_MESSAGES.FORBIDDEN);
+      return;
+    }
+
+    next();
+  };
+}
+
+export function requireAnyPermission(permissions: ALL_PERMISSIONS[]): RequestHandler {
+  return function(req: Request, res: Response, next: NextFunction) {
+    const {user} = req;
+    const householdId = req.params.id;
+
+    if(!user || !householdId) {
+      res.apiError(401, ERROR_MESSAGES.UNAUTHORIZED);
+      return;
+    }
+
+    if(!hasAnyPermission(user, householdId, permissions)) {
+      res.apiError(403, ERROR_MESSAGES.FORBIDDEN);
+      return;
+    }
+
+    next();
+  };
+}
+
+export function requireAllPermissions(permissions: ALL_PERMISSIONS[]): RequestHandler {
+  return function(req: Request, res: Response, next: NextFunction) {
+    const {user} = req;
+    const householdId = req.params.id;
+
+    if(!user || !householdId) {
+      res.apiError(401, ERROR_MESSAGES.UNAUTHORIZED);
+      return;
+    }
+
+    if(!hasAllPermissions(user, householdId, permissions)) {
+      res.apiError(403, ERROR_MESSAGES.FORBIDDEN);
+      return;
+    }
+
+    next();
+  };
+}

--- a/backend/src/models/user.ts
+++ b/backend/src/models/user.ts
@@ -50,7 +50,7 @@ const userSchema = new Schema<IUserBackend, IUserModel, IUserMethods>(
     toObject: { virtuals: true },
 
     methods: {
-      async addHousehold(this: UserDocument, householdId: string, role: HouseholdRoles): Promise<void> {
+      async addHouseholdRole(this: UserDocument, householdId: string, role: HouseholdRoles): Promise<void> {
         this.householdRoles.set(householdId, role);
         await this.save();
       },

--- a/backend/src/services/permission.ts
+++ b/backend/src/services/permission.ts
@@ -1,0 +1,55 @@
+/* eslint-disable @typescript-eslint/no-unnecessary-condition */
+import * as roles from '../config/roles';
+
+import type { ALL_PERMISSIONS } from '../config/permissions';
+import type { SafeUser } from '../types/user';
+
+const PERMISSION_SETS = {
+  owner:  new Set<ALL_PERMISSIONS>(roles.Owner),
+  admin:  new Set<ALL_PERMISSIONS>(roles.Admin),
+  member: new Set<ALL_PERMISSIONS>(roles.Member),
+  guest:  new Set<ALL_PERMISSIONS>(roles.Guest)
+};
+
+export function hasPermission(user: SafeUser, householdId: string, permission: ALL_PERMISSIONS): boolean {
+  const role = user.householdRoles[householdId];
+
+  if(!role) {
+    return false;
+  }
+
+  const permissionSet = PERMISSION_SETS[role];
+
+  return permissionSet.has(permission);
+}
+
+export function hasAnyPermission(user: SafeUser, householdId: string, permissions: ALL_PERMISSIONS[]): boolean {
+  const role = user.householdRoles[householdId];
+  if(!role) {
+    return false;
+  }
+  const permissionSet = PERMISSION_SETS[role];
+  return permissions.some(val => permissionSet.has(val));
+}
+
+
+export function hasAllPermissions(user: SafeUser, householdId: string, permissions: ALL_PERMISSIONS[]): boolean {
+  const role = user.householdRoles[householdId];
+  if(!role) {
+    return false;
+  }
+
+  const permissionSet = PERMISSION_SETS[role];
+
+  return permissions.every(val => permissionSet.has(val));
+}
+
+export function getUserPermissions(user: SafeUser, householdId: string): ALL_PERMISSIONS[] {
+  const role = user.householdRoles[householdId];
+  if(!role) {
+    throw new ReferenceError('User is not assigned a role for household');
+  }
+
+  const permissions = Array.from(PERMISSION_SETS[role]);
+  return permissions;
+}

--- a/backend/src/types/user.d.ts
+++ b/backend/src/types/user.d.ts
@@ -26,7 +26,7 @@ export type SafeUserBackend = Omit<IUserBackend, 'password'>;
  * Methods available on User document instances
  */
 export interface IUserMethods {
-  addHousehold(householdId: string, role: HouseholdRoles): Promise<void>;
+  addHouseholdRole(householdId: string, role: HouseholdRoles): Promise<void>;
   comparePassword(password: string): Promise<boolean>;
   toSafeObject(): SafeUser; // Returns frontend-compatible SafeUser
   toJSON(): SafeUser; // Returns frontend-compatible SafeUser

--- a/backend/src/utils/extractTypes.ts
+++ b/backend/src/utils/extractTypes.ts
@@ -1,0 +1,6 @@
+/**
+ * Utility types to extract types from values. 
+ */
+
+export type SetElementType<T> = T extends Set<infer U> ? U : never;
+export type ValuesOfObject<T> = T[keyof T];

--- a/backend/tests/helpers/testDataUtils.ts
+++ b/backend/tests/helpers/testDataUtils.ts
@@ -2,7 +2,7 @@ import { Types } from 'mongoose';
 import { User } from '../../src/models/user';
 import { Household } from '../../src/models/household';
 import type { SafeUser, UserDocument } from '../../src/types/user';
-import type { HouseholdDocument } from '../../src/models/household';
+import type { HouseholdDocument, IHousehold } from '../../src/models/household';
 import { HouseholdRoles } from '@homekeeper/shared';
 
 // =============================================================================

--- a/backend/tests/middleware/rbac.test.ts
+++ b/backend/tests/middleware/rbac.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+import { requireAllPermissions, requireAnyPermission, requirePermission } from '../../src/middleware/rbac';
+import { createMockHousehold, createMockUser } from '../helpers/testDataUtils';
+import { HouseholdPermissions } from '../../src/config/permissions';
+
+import type { NextFunction, Request, Response } from 'express';
+import { SafeUser } from '../../src/types/user';
+import { ApiResponse } from '@homekeeper/shared';
+
+describe('RBAC Middleware', () => {
+  let mockUser: SafeUser;
+  let mockHouse: any;
+  let mockRequest: Partial<Request & { user?: SafeUser }>;
+  let mockResponse: Partial<Response & {
+    apiSuccess<T>(data: ApiResponse<T>): Response;
+    apiError(statusCode: number, error: string): Response;
+  }>;
+  let mockNext: NextFunction;
+
+  beforeEach(() => {
+    mockHouse = createMockHousehold();
+    mockUser = createMockUser({
+      householdRoles: {
+        [mockHouse.id]: 'admin'
+      }
+    });
+
+    mockNext = vi.fn();
+
+    mockRequest = {
+      user: undefined,
+      params: {}
+    };
+
+    mockResponse = {
+      apiSuccess: vi.fn().mockReturnThis(),
+      apiError: vi.fn().mockReturnThis(),
+    }
+  });
+
+  describe('Require A Permission', () => {
+    it('should return 401 if user is missing', () => {
+      const mw = requirePermission(HouseholdPermissions.HOUSEHOLD_DELETE);
+      void mw(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockResponse.apiError).toHaveBeenCalledWith(401, 'Unauthorized');
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it('should return 401 if household id is missing', () => {
+      mockRequest.user = mockUser;
+      const mw = requirePermission(HouseholdPermissions.HOUSEHOLD_DELETE);
+      void mw(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockResponse.apiError).toHaveBeenCalledWith(401, 'Unauthorized');
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it('should return 403 if user does not have permission', () => {
+      mockRequest.user = mockUser;
+      mockRequest.params = {
+        id: mockHouse.id
+      };
+
+      const mw = requirePermission(HouseholdPermissions.HOUSEHOLD_DELETE);
+      void mw(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockResponse.apiError).toHaveBeenCalledWith(403, 'Forbidden');
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it('should call next if user has permission', () => {
+      mockRequest.user = mockUser;
+      mockRequest.params = {
+        id: mockHouse.id
+      };
+
+      const mw = requirePermission(HouseholdPermissions.HOUSEHOLD_VIEW);
+      void mw(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockNext).toHaveBeenCalled();
+    });
+  });
+
+  describe('Require Any Permission', () => {
+    it('should return 401 if user is missing', () => {
+      const mw = requireAnyPermission([HouseholdPermissions.HOUSEHOLD_DELETE, HouseholdPermissions.HOUSEHOLD_UPDATE]);
+      void mw(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockResponse.apiError).toHaveBeenCalledWith(401, 'Unauthorized');
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it('should return 401 if household id is missing', () => {
+      mockRequest.user = mockUser;
+      const mw = requireAnyPermission([HouseholdPermissions.HOUSEHOLD_DELETE, HouseholdPermissions.HOUSEHOLD_UPDATE]);
+      void mw(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockResponse.apiError).toHaveBeenCalledWith(401, 'Unauthorized');
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it('should return 403 if user does not have any permission', () => {
+      mockRequest.user = mockUser;
+      mockRequest.params = {
+        id: mockHouse.id
+      };
+
+      // Admin doesn't have DELETE or TRANSFER_OWNERSHIP permissions
+      const mw = requireAnyPermission([HouseholdPermissions.HOUSEHOLD_DELETE, HouseholdPermissions.HOUSEHOLD_TRANSFER_OWNERSHIP]);
+      void mw(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockResponse.apiError).toHaveBeenCalledWith(403, 'Forbidden');
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it('should call next if user has at least one permission', () => {
+      mockRequest.user = mockUser;
+      mockRequest.params = {
+        id: mockHouse.id
+      };
+
+      // Admin has VIEW and UPDATE but not DELETE
+      const mw = requireAnyPermission([HouseholdPermissions.HOUSEHOLD_VIEW, HouseholdPermissions.HOUSEHOLD_DELETE]);
+      void mw(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockNext).toHaveBeenCalled();
+    });
+  });
+
+  describe('Require All Permissions', () => {
+    it('should return 401 if user is missing', () => {
+      const mw = requireAllPermissions([HouseholdPermissions.HOUSEHOLD_VIEW, HouseholdPermissions.HOUSEHOLD_UPDATE]);
+      void mw(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockResponse.apiError).toHaveBeenCalledWith(401, 'Unauthorized');
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it('should return 401 if household id is missing', () => {
+      mockRequest.user = mockUser;
+      const mw = requireAllPermissions([HouseholdPermissions.HOUSEHOLD_VIEW, HouseholdPermissions.HOUSEHOLD_UPDATE]);
+      void mw(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockResponse.apiError).toHaveBeenCalledWith(401, 'Unauthorized');
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it('should return 403 if user does not have all permissions', () => {
+      mockRequest.user = mockUser;
+      mockRequest.params = {
+        id: mockHouse.id
+      };
+
+      // Admin has VIEW and UPDATE but not DELETE
+      const mw = requireAllPermissions([HouseholdPermissions.HOUSEHOLD_VIEW, HouseholdPermissions.HOUSEHOLD_DELETE]);
+      void mw(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockResponse.apiError).toHaveBeenCalledWith(403, 'Forbidden');
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it('should call next if user has all permissions', () => {
+      mockRequest.user = mockUser;
+      mockRequest.params = {
+        id: mockHouse.id
+      };
+
+      // Admin has both VIEW and UPDATE permissions
+      const mw = requireAllPermissions([HouseholdPermissions.HOUSEHOLD_VIEW, HouseholdPermissions.HOUSEHOLD_UPDATE]);
+      void mw(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockNext).toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/tests/models/user.test.ts
+++ b/backend/tests/models/user.test.ts
@@ -162,7 +162,7 @@ describe('User Model Tests', () => {
       it('should add household role using Map.set', async () => {
         const householdId = new Types.ObjectId().toString();
 
-        await user.addHousehold(householdId, 'admin');
+        await user.addHouseholdRole(householdId, 'admin');
 
         // Verify the Map was updated
         expect(user.householdRoles.get(householdId)).toBe('admin');
@@ -177,8 +177,8 @@ describe('User Model Tests', () => {
         const household1 = new Types.ObjectId().toString();
         const household2 = new Types.ObjectId().toString();
 
-        await user.addHousehold(household1, 'owner');
-        await user.addHousehold(household2, 'member');
+        await user.addHouseholdRole(household1, 'owner');
+        await user.addHouseholdRole(household2, 'member');
 
         expect(user.householdRoles.get(household1)).toBe('owner');
         expect(user.householdRoles.get(household2)).toBe('member');
@@ -188,10 +188,10 @@ describe('User Model Tests', () => {
       it('should update existing household role', async () => {
         const householdId = new Types.ObjectId().toString();
 
-        await user.addHousehold(householdId, 'member');
+        await user.addHouseholdRole(householdId, 'member');
         expect(user.householdRoles.get(householdId)).toBe('member');
 
-        await user.addHousehold(householdId, 'admin');
+        await user.addHouseholdRole(householdId, 'admin');
         expect(user.householdRoles.get(householdId)).toBe('admin');
         expect(user.householdRoles.size).toBe(1); // Should still be 1
       });
@@ -202,8 +202,8 @@ describe('User Model Tests', () => {
         const household1 = new Types.ObjectId().toString();
         const household2 = new Types.ObjectId().toString();
 
-        await user.addHousehold(household1, 'owner');
-        await user.addHousehold(household2, 'admin');
+        await user.addHouseholdRole(household1, 'owner');
+        await user.addHouseholdRole(household2, 'admin');
 
         const safeUser = user.toSafeObject();
 
@@ -234,7 +234,7 @@ describe('User Model Tests', () => {
     describe('toJSON method', () => {
       it('should return same as toSafeObject', async () => {
         const householdId = new Types.ObjectId().toString();
-        await user.addHousehold(householdId, 'member');
+        await user.addHouseholdRole(householdId, 'member');
 
         const jsonResult = user.toJSON();
         const safeResult = user.toSafeObject();

--- a/backend/tests/routes/household.test.ts
+++ b/backend/tests/routes/household.test.ts
@@ -182,8 +182,6 @@ describe('Household Routes (Integration)', () => {
       expect(response.status).toBe(HTTP_STATUS.UNAUTHORIZED);
       expect(response.body.error).toBe('Unauthorized');
     });
-
-    it.todo('should return household when user is added as non-owner member');
   });
 
   describe('PUT /:id', () => {
@@ -262,8 +260,27 @@ describe('Household Routes (Integration)', () => {
       expect(response.body.error).toBe('Unauthorized');
     });
 
-    it.todo('should return 403 when user is member but not owner');
-    it.todo('should return 403 when user is admin but not owner');
+    it('should return 403 when user is not the owner', async () => {
+      const { user: owner, household } = await createTestUserWithHousehold();
+      const memberUser = await insertTestUser({ email: 'member@example.com' });
+
+      // Add member to household with 'member' role
+      await household.addMember(memberUser._id.toString(), 'member');
+      const token = createAuthToken(memberUser.toSafeObject());
+
+      const updateData = {
+        name: 'Member trying to update',
+        description: 'Should fail'
+      };
+
+      const response = await request
+        .put(`/households/${household._id}`)
+        .set('Cookie', [`${JWT_COOKIE_NAME}=${token}`])
+        .send(updateData);
+
+      expect(response.status).toBe(HTTP_STATUS.FORBIDDEN);
+      expect(response.body.error).toBe('Forbidden');
+    });
   });
 
   describe('DELETE /:id', () => {
@@ -304,8 +321,27 @@ describe('Household Routes (Integration)', () => {
       expect(response.body.error).toBe('Unauthorized');
     });
 
-    it.todo('should return 403 when user is member but not owner');
-    it.todo('should return 403 when user is admin but not owner');
+    it('should return 403 when user is not the owner', async () => {
+      const { user: owner, household } = await createTestUserWithHousehold();
+      const memberUser = await insertTestUser({ email: 'member@example.com' });
+
+      // Add member to household with 'member' role
+      await household.addMember(memberUser._id.toString(), 'member');
+      const token = createAuthToken(memberUser.toSafeObject());
+
+      const updateData = {
+        name: 'Member trying to update',
+        description: 'Should fail'
+      };
+
+      const response = await request
+        .delete(`/households/${household._id}`)
+        .set('Cookie', [`${JWT_COOKIE_NAME}=${token}`])
+        .send(updateData);
+
+      expect(response.status).toBe(HTTP_STATUS.FORBIDDEN);
+      expect(response.body.error).toBe('Forbidden');
+    });
   });
 
   describe('ownership verification', () => {
@@ -340,12 +376,5 @@ describe('Household Routes (Integration)', () => {
 
       expect(response.status).toBe(HTTP_STATUS.NO_CONTENT);
     });
-  });
-
-  describe('member management', () => {
-    it.todo('should handle households with multiple members');
-    it.todo('should respect role-based permissions when roles are implemented');
-    it.todo('should allow admins to perform certain operations');
-    it.todo('should restrict guests to read-only operations');
   });
 });

--- a/backend/tests/services/permission.test.ts
+++ b/backend/tests/services/permission.test.ts
@@ -1,0 +1,121 @@
+import {describe, it, expect, beforeEach} from 'vitest';
+
+import * as permissions from '../../src/config/permissions';
+import * as roles from '../../src/config/roles';
+
+import {
+  hasAllPermissions,
+  hasAnyPermission,
+  hasPermission,
+  getUserPermissions
+} from '../../src/services/permission';
+
+import { createMockUser } from '../helpers/testDataUtils';
+import { SafeUser } from '../../src/types/user';
+
+describe('Permissions Management', () => {
+  let mockUser: SafeUser;
+
+  beforeEach(() => {
+    mockUser = createMockUser({
+        householdRoles: {
+        'owner-household-id': 'owner',
+        'admin-household-id': 'admin', 
+        'member-household-id': 'member',
+        'guest-household-id': 'guest'
+      }
+    });
+  });
+
+  describe('Checking Permissions', () => {
+    it('should be able to determine if a user has a permission', () => {
+      const ownerPerm  = hasPermission(mockUser, 'owner-household-id', permissions.HouseholdPermissions.HOUSEHOLD_DELETE);
+      const adminPerm  = hasPermission(mockUser, 'admin-household-id', permissions.HouseholdPermissions.HOUSEHOLD_INVITE_MEMBERS);
+      const memberPerm = hasPermission(mockUser, 'member-household-id', permissions.AssetPermissions.ASSET_UPDATE);
+      const guestPerm  = hasPermission(mockUser, 'guest-household-id', permissions.DocumentPermissions.DOCUMENT_VIEW);
+      
+      expect(ownerPerm).toBeTruthy();
+      expect(adminPerm).toBeTruthy();
+      expect(memberPerm).toBeTruthy();
+      expect(guestPerm).toBeTruthy();
+    });
+
+    it('should be able to report if a user does not have a permission', () => {
+      const adminPerm  = hasPermission(mockUser, 'admin-household-id', permissions.HouseholdPermissions.HOUSEHOLD_DELETE);
+      const memberPerm = hasPermission(mockUser, 'member-household-id', permissions.AssetPermissions.ASSET_DELETE);
+      const guestPerm  = hasPermission(mockUser, 'guest-household-id', permissions.DocumentPermissions.DOCUMENT_CREATE);
+      
+      expect(adminPerm).toBeFalsy();
+      expect(memberPerm).toBeFalsy();
+      expect(guestPerm).toBeFalsy();
+
+      const adminPermFail  = hasAnyPermission(mockUser, 'admin-household-id',  [permissions.HouseholdPermissions.HOUSEHOLD_DELETE]);
+      const memberPermFail = hasAnyPermission(mockUser, 'member-household-id', [permissions.HouseholdPermissions.HOUSEHOLD_INVITE_MEMBERS, permissions.HouseholdPermissions.HOUSEHOLD_DELETE]);
+      const guestPermFail  = hasAnyPermission(mockUser, 'guest-household-id',  [permissions.DocumentPermissions.DOCUMENT_DELETE, permissions.HouseholdPermissions.HOUSEHOLD_DELETE]);
+      
+      expect(adminPermFail).toBeFalsy();
+      expect(memberPermFail).toBeFalsy();
+      expect(guestPermFail).toBeFalsy();
+    });
+
+    it('should be able to report if a user has at least one required permission', () => {
+      const ownerPerm  = hasAnyPermission(mockUser, 'owner-household-id',  [permissions.HouseholdPermissions.HOUSEHOLD_DELETE, permissions.HouseholdPermissions.HOUSEHOLD_INVITE_MEMBERS]);
+      const adminPerm  = hasAnyPermission(mockUser, 'admin-household-id',  [permissions.HouseholdPermissions.HOUSEHOLD_INVITE_MEMBERS, permissions.HouseholdPermissions.HOUSEHOLD_DELETE]);
+      const memberPerm = hasAnyPermission(mockUser, 'member-household-id', [permissions.AssetPermissions.ASSET_UPDATE, permissions.HouseholdPermissions.HOUSEHOLD_DELETE]);
+      const guestPerm  = hasAnyPermission(mockUser, 'guest-household-id',  [permissions.DocumentPermissions.DOCUMENT_VIEW, permissions.HouseholdPermissions.HOUSEHOLD_DELETE]);
+      
+      expect(ownerPerm).toBeTruthy();
+      expect(adminPerm).toBeTruthy();
+      expect(memberPerm).toBeTruthy();
+      expect(guestPerm).toBeTruthy();
+    });
+
+    it('should be able to report if a user has all permissions', () => {
+      const ownerPerm  = hasAllPermissions(mockUser, 'owner-household-id',  [permissions.HouseholdPermissions.HOUSEHOLD_DELETE, permissions.HouseholdPermissions.HOUSEHOLD_INVITE_MEMBERS]);
+      const adminPerm  = hasAllPermissions(mockUser, 'admin-household-id',  [permissions.HouseholdPermissions.HOUSEHOLD_INVITE_MEMBERS, permissions.AssetPermissions.ASSET_UPDATE]);
+      const memberPerm = hasAllPermissions(mockUser, 'member-household-id', [permissions.AssetPermissions.ASSET_UPDATE, permissions.DocumentPermissions.DOCUMENT_VIEW]);
+      const guestPerm  = hasAllPermissions(mockUser, 'guest-household-id',  [permissions.DocumentPermissions.DOCUMENT_VIEW, permissions.HouseholdPermissions.HOUSEHOLD_VIEW]);
+      
+      expect(ownerPerm).toBeTruthy();
+      expect(adminPerm).toBeTruthy();
+      expect(memberPerm).toBeTruthy();
+      expect(guestPerm).toBeTruthy();
+    });
+
+    it('should be able to report if a user does not have all required permissions', () => {
+      const adminPerm  = hasAllPermissions(mockUser, 'admin-household-id',  [permissions.HouseholdPermissions.HOUSEHOLD_INVITE_MEMBERS, permissions.HouseholdPermissions.HOUSEHOLD_DELETE]);
+      const memberPerm = hasAllPermissions(mockUser, 'member-household-id', [permissions.AssetPermissions.ASSET_UPDATE, permissions.HouseholdPermissions.HOUSEHOLD_DELETE]);
+      const guestPerm  = hasAllPermissions(mockUser, 'guest-household-id',  [permissions.DocumentPermissions.DOCUMENT_VIEW, permissions.HouseholdPermissions.HOUSEHOLD_DELETE]);
+      
+      expect(adminPerm).toBeFalsy();
+      expect(memberPerm).toBeFalsy();
+      expect(guestPerm).toBeFalsy();
+    });
+
+    it('should return false if user does not have a role for a household', () => {
+      const one = hasPermission(mockUser, 'not-a-house', permissions.HouseholdPermissions.HOUSEHOLD_VIEW)
+      const any = hasAnyPermission(mockUser, 'not-a-house', [permissions.HouseholdPermissions.HOUSEHOLD_VIEW]);
+      const all = hasAllPermissions(mockUser, 'not-a-house', [permissions.HouseholdPermissions.HOUSEHOLD_VIEW]);
+
+      expect(one).toBeFalsy()
+      expect(any).toBeFalsy()
+      expect(all).toBeFalsy()
+    });
+
+    it('should be able to return the permissions a user has for a household', () => {
+      const ownerPerm  = getUserPermissions(mockUser, 'owner-household-id');
+      const adminPerm  = getUserPermissions(mockUser, 'admin-household-id');
+      const memberPerm = getUserPermissions(mockUser, 'member-household-id');
+      const guestPerm  = getUserPermissions(mockUser, 'guest-household-id');
+      
+      expect(ownerPerm).toEqual(roles.Owner);
+      expect(adminPerm).toEqual(roles.Admin);
+      expect(memberPerm).toEqual(roles.Member);
+      expect(guestPerm).toEqual(roles.Guest);
+    });
+
+    it('should throw an error if trying to get permissions for a non-existant house', () => {
+      expect(() => getUserPermissions(mockUser, 'not-a-house')).toThrow();
+    });
+  });
+});

--- a/shared/src/types/user.ts
+++ b/shared/src/types/user.ts
@@ -16,7 +16,7 @@ export interface IUser {
     defaultHouseholdId?: string;
   };
   householdRoles: {
-    [householdId: string]: 'owner' | 'admin' | 'member' | 'guest';
+    [householdId: string]: HouseholdRoles
   };
 }
 


### PR DESCRIPTION
Using definition of household roles, create (potential) permissions for each document and assign to different roles. This may be updated in the future. A service provides methods for checking whether the user has permission based on their role, and we make middleware to enforce the permission.

This is only hooked up to some routes on household for now. Had to update household and household tests to get everything working correctly.

Unit tests are passing.